### PR TITLE
fix: prevent bot interference during manual race retry decision

### DIFF
--- a/core/actions/race.py
+++ b/core/actions/race.py
@@ -63,6 +63,7 @@ class RaceFlow:
             "retry_skipped": 0,
             "wins_or_no_loss": 0,
         }
+        self._waiting_for_manual_retry_decision = False
 
     def _ensure_in_raceday(
         self, *, reason: str | None = None, from_raceday=False
@@ -847,7 +848,7 @@ class RaceFlow:
             classes=("button_green",),
             texts=("TRY AGAIN",),
             tag="race_try_again_probe",
-            threshold=0.62,
+            threshold=0.3,
         )
         if loss_indicator_seen:
             self._race_result_counters["loss_indicators"] += 1
@@ -870,6 +871,7 @@ class RaceFlow:
             logger_uma.warning(
                 "[race] Stopping bot so user can choose Try Again or Cancel manually."
             )
+            self._waiting_for_manual_retry_decision = True
             request_abort()
             return False
 
@@ -1069,6 +1071,9 @@ class RaceFlow:
           - if from_raceday == True → raise ConsecutiveRaceRefused
           - else → return False (let caller continue with its skip logic)
         """
+        # Reset manual retry decision flag at the start of a new race
+        self._waiting_for_manual_retry_decision = False
+        
         logger_uma.info(
             "[race] RaceDay begin (prioritize_g1=%s, is_g1_goal=%s)%s",
             prioritize_g1,

--- a/core/actions/unity_cup/agent.py
+++ b/core/actions/unity_cup/agent.py
@@ -147,6 +147,13 @@ class AgentUnityCup(AgentScenario):
                 self._consecutive_event_stale_clicks = 0
 
             if unknown_screen:
+                # Check if race flow is waiting for manual retry decision
+                if hasattr(self, 'race') and self.race._waiting_for_manual_retry_decision:
+                    logger_uma.warning(
+                        "[agent] Waiting for manual retry decision. Skipping all button clicks."
+                    )
+                    sleep(1.0)
+                    continue
                 # Reset event stale counters when on unknown screen
                 self._single_event_option_counter = 0
 
@@ -405,7 +412,7 @@ class AgentUnityCup(AgentScenario):
                         reason="Pre-debut (race day)",
                     )
                     if not ok:
-                        raise RuntimeError("Couldn't race")
+                        raise RuntimeError("Couldn't race or stopped due to dangerouse action")
                     # Mark raced on current date-key to avoid double-race if date OCR doesn't tick
                     self.lobby.mark_raced_today(self._today_date_key())
                     continue
@@ -417,7 +424,7 @@ class AgentUnityCup(AgentScenario):
                         reason="Normal (race day)",
                     )
                     if not ok:
-                        raise RuntimeError("Couldn't race")
+                        raise RuntimeError("Couldn't race or stopped due to dangerouse action")
                     self.lobby.mark_raced_today(self._today_date_key())
                     continue
             

--- a/core/actions/ura/agent.py
+++ b/core/actions/ura/agent.py
@@ -137,6 +137,13 @@ class AgentURA(AgentScenario):
                 self._consecutive_event_stale_clicks = 0
 
             if unknown_screen:
+                # Check if race flow is waiting for manual retry decision
+                if hasattr(self, 'race') and self.race._waiting_for_manual_retry_decision:
+                    logger_uma.warning(
+                        "[agent] Waiting for manual retry decision. Skipping all button clicks."
+                    )
+                    sleep(1.0)
+                    continue
                 # Reset event stale counters when on unknown screen
                 self._single_event_option_counter = 0
                 threshold = 0.65

--- a/core/utils/text.py
+++ b/core/utils/text.py
@@ -166,6 +166,7 @@ def fuzzy_contains(
             if ratio >= threshold:
                 if return_ratio:
                     return True, ratio
+                return True
 
     if return_ratio:
         return False, 0


### PR DESCRIPTION
#75
- Added _waiting_for_manual_retry_decision flag to track manual intervention state
- Lowered TRY AGAIN detection threshold (0.62→0.3) for more reliable loss detection
- Paused button clicks in Unity Cup and URA agents when waiting for manual retry choice
- Reset manual retry flag at start of each new race
- Fixed fuzzy_contains missing return statement for non-ratio path
- Updated error messages to clarify race failure vs. dangerous